### PR TITLE
Configure the "CI" workflow for merge queues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: [push, pull_request, merge_group]
 
 name: CI
 


### PR DESCRIPTION
The `merge_group` event must be used to trigger required GitHub Actions workflows when a pull request is added to a merge queue [0].

We require the "CI/CI" check to pass for PRs to be merged so we must trigger the "CI" workflow on `merge_group` events.

[0]: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue

<details>
<!-- Any extra information below the details tag line above won't be included in the merge commit from bors (useful for questions, notes, etc.). -->
<!-- Also: Please read CONTRIBUTING.md first and consider the checklist. -->
</details>
